### PR TITLE
fix(docs): correct local urls to use http

### DIFF
--- a/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-as-a-library-in-docker.md
@@ -212,8 +212,8 @@ the command `$ docker-machine ip default`.
 
 | Container                 | Docker on Linux / Windows Pro     | Docker on Windows Home                         |
 | ------------------------- | --------------------------------- | ---------------------------------------------- |
-| GraphQL API Documentation | `https://localhost:5433/graphiql` | `https://your_docker_machine_ip:5433/graphiql` |
-| GraphQL API               | `https://localhost:5433/graphql`  | `https://your_docker_machine_ip:5433/graphql`  |
+| GraphQL API Documentation | `http://localhost:5433/graphiql`  | `http://your_docker_machine_ip:5433/graphiql`  |
+| GraphQL API               | `http://localhost:5433/graphql`   | `http://your_docker_machine_ip:5433/graphql`   |
 | PostgreSQL Database       | host: `localhost`, port: `5432`   | host: `your_docker_machine_ip`, port: `5432`   |
 
 #### Re-initialize The Database

--- a/src/pages/postgraphile/running-postgraphile-in-docker.md
+++ b/src/pages/postgraphile/running-postgraphile-in-docker.md
@@ -390,8 +390,8 @@ Each container can be accessed at the following addresses.
 
 | Container                 | Docker on Linux / Windows Pro     | Docker on Windows Home                         |
 | ------------------------- | --------------------------------- | ---------------------------------------------- |
-| GraphQL API Documentation | `https://localhost:5433/graphiql` | `https://your_docker_machine_ip:5433/graphiql` |
-| GraphQL API               | `https://localhost:5433/graphql`  | `https://your_docker_machine_ip:5433/graphql`  |
+| GraphQL API Documentation | `http://localhost:5433/graphiql`  | `http://your_docker_machine_ip:5433/graphiql`  |
+| GraphQL API               | `http://localhost:5433/graphql`   | `http://your_docker_machine_ip:5433/graphql`   |
 | PostgreSQL Database       | host: `localhost`, port: `5432`   | host: `your_docker_machine_ip`, port: `5432`   |
 
 > Note: if you run Docker Toolbox on Windows Home, you can get your Docker


### PR DESCRIPTION
As documented (and by default) local docker-compose endpoints are not HTTPS, they are HTTP. While certainly possible to run with HTTPS, as configured, they are HTTP listeners, and anyone visiting the exact URL will experience an error despite the HTTP URL working just fine.